### PR TITLE
Add ability to specify redirect names

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -99,6 +99,17 @@ app_nginx_limitreq_enabled: false
 # the maximum requests per second per client IP address to throw HTTP error
 app_nginx_limitreq_per_second: 10
 
+# a list of domain names that nginx should handle and redirect to the main name
+app_nginx_redirect_names: []
+_app_nginx_redirect_names_item:
+  name: "_"
+  ssl_enabled: no
+  ssl_spdy_enabled: yes
+  ssl_cert_path: ""
+  ssl_priv_path: ""
+  ssl_only: no
+  redirect_code: 301
+
 
 # dependencies in order to fully run rbenv
 app_puma_apt_dependencies:

--- a/templates/nginx.conf.j2
+++ b/templates/nginx.conf.j2
@@ -11,18 +11,9 @@ server {
 {% endif -%}
 
 {% for redirector in app_nginx_redirect_names %}
-{% if redirector.ssl_enabled and redirector.ssl_only -%}
 server {
     server_name {{ redirector.name }};
-    listen 80; listen [::]:80;
-    return {{ redirector.redirect_code }} https://{{ app_name }}$request_uri;
-}
-{% endif -%}
-
-server {
-    server_name {{ redirector.name }};
-
-    {% if not redirector.ssl_only %}
+    {% if not redirector.ssl_only -%}
     listen 80; listen [::]:80;
     {% endif %}
 
@@ -32,11 +23,9 @@ server {
 
     ssl_certificate {{ redirector.ssl_cert_path }};
     ssl_certificate_key {{ redirector.ssl_priv_path }};
-
-    return {{ redirector.redirect_code }} https://{{ app_name }}$request_uri;
-    {% else %}
-    return {{ redirector.redirect_code }} http://{{ app_name }}$request_uri;
     {% endif %}
+
+    return {{ redirector.redirect_code }} http{% if app_nginx_ssl_enabled %}s{% endif %}://{{ app_name }}$request_uri;
 }
 {% endfor %}
 

--- a/templates/nginx.conf.j2
+++ b/templates/nginx.conf.j2
@@ -10,6 +10,36 @@ server {
 }
 {% endif -%}
 
+{% for redirector in app_nginx_redirect_names %}
+{% if redirector.ssl_enabled and redirector.ssl_only -%}
+server {
+    server_name {{ redirector.name }};
+    listen 80; listen [::]:80;
+    return {{ redirector.redirect_code }} https://{{ app_name }}$request_uri;
+}
+{% endif -%}
+
+server {
+    server_name {{ redirector.name }};
+
+    {% if not redirector.ssl_only %}
+    listen 80; listen [::]:80;
+    {% endif %}
+
+    {% if redirector.ssl_enabled -%}
+    listen 443 ssl {% if redirector.ssl_spdy_enabled %}http2{% endif %};
+    listen [::]:443 ssl {% if redirector.ssl_spdy_enabled %}http2{% endif %};
+
+    ssl_certificate {{ redirector.ssl_cert_path }};
+    ssl_certificate_key {{ redirector.ssl_priv_path }};
+
+    return {{ redirector.redirect_code }} https://{{ app_name }}$request_uri;
+    {% else %}
+    return {{ redirector.redirect_code }} http://{{ app_name }}$request_uri;
+    {% endif %}
+}
+{% endfor %}
+
 server {
     server_name {{ app_name }};
 


### PR DESCRIPTION
This PR adds the ability to specify a list of domain names that will be redirected to the main domain name for the service. For example, the user can specify that "test-one.domain.name" and "test-two.domain.name" will redirect to "test.domain.name" with the rest of the request URI intact.